### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/igarridot/Pentaract/security/code-scanning/3](https://github.com/igarridot/Pentaract/security/code-scanning/3)

In general, the fix is to explicitly restrict the GITHUB_TOKEN permissions in the workflow to the minimum required. Since both jobs only need to check out code and fetch dependencies, they only require read access to repository contents, and possibly to packages/metadata. The simplest safe fix, matching CodeQL’s suggestion, is to add a `permissions:` block at the workflow root so it applies to all jobs that don’t override it.

The best fix here is to add a root-level `permissions:` entry immediately after the `name: Tests` line (before `on:`). For these test jobs, `contents: read` is sufficient as a minimal starting point; none of the steps push commits, manage issues, or alter workflows. This change does not modify any existing steps or their behavior; it only constrains the automatically provided GITHUB_TOKEN. No additional imports, methods, or definitions are needed, as this is a pure YAML configuration change within `.github/workflows/tests.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
