### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish-tag.yml
+++ b/.github/workflows/docker-publish-tag.yml
@@ -1,5 +1,8 @@
 name: Publish Docker Image
 
+permissions:
+  contents: read
+
 on:
   release:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/igarridot/Pentaract/security/code-scanning/2](https://github.com/igarridot/Pentaract/security/code-scanning/2)

To fix the problem, explicitly declare `permissions` for the workflow (or job) so that the `GITHUB_TOKEN` is limited to the least privilege needed. This workflow only checks out code and builds/pushes a Docker image to Docker Hub using credentials from secrets; it does not need to write to the repository or to GitHub issues, PRs, etc. A safe minimal set is `contents: read` at the workflow root, which will apply to all jobs unless overridden.

The best single change without affecting existing functionality is to add a root-level `permissions` block immediately after the workflow `name:` declaration. This will restrict the `GITHUB_TOKEN` to read-only access to repository contents, which is sufficient for `actions/checkout` and for the other Docker-related actions that rely on secrets and Docker Hub credentials, not GitHub write permissions. No imports or additional methods are needed; it’s purely a YAML configuration change in `.github/workflows/docker-publish-tag.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
