### PR TITLE
fix(ui): pin transitive yaml >=1.10.3 to close GHSA-48c2-rrv3-qjmp

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -24,5 +24,10 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "vite": "^8.0.16"
+  },
+  "pnpm": {
+    "overrides": {
+      "yaml@<1.10.3": "^1.10.3"
+    }
   }
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  yaml@<1.10.3: ^1.10.3
+
 importers:
 
   .:
@@ -906,8 +909,8 @@ packages:
       yaml:
         optional: true
 
-  yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
 snapshots:
@@ -1354,7 +1357,7 @@ snapshots:
       import-fresh: 3.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.2
+      yaml: 1.10.3
 
   csstype@3.2.3: {}
 
@@ -1627,4 +1630,4 @@ snapshots:
       esbuild: 0.27.3
       fsevents: 2.3.3
 
-  yaml@1.10.2: {}
+  yaml@1.10.3: {}


### PR DESCRIPTION
## Summary

Closes Dependabot alert #5 (`yaml@1.10.2` → CVE-2026-33532, medium).

`yaml@1.10.2` is pulled in transitively through `@mui/material → @emotion/babel-plugin → babel-plugin-macros → cosmiconfig@7.1.0`. None of that runs in the browser bundle — it executes only at build time inside the Vite/babel pipeline — so there's no untrusted YAML being parsed in production. Still, the alert needs to be closed.

A scoped `pnpm.overrides` entry forces the patched `1.10.3` without touching the `yaml@2.x` line or any upstream package's `package.json`.

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm test` — 55/55 passing
- [x] `pnpm-lock.yaml` shows `yaml@1.10.3` (was `1.10.2`)