### PR TITLE
fix(docker): copy pnpm-workspace.yaml so the UI image actually builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o pentaract ./
 FROM public.ecr.aws/docker/library/node:latest AS ui
 
 WORKDIR /app
-COPY ui/package.json ui/pnpm-lock.yaml* ./
-RUN npm install -g pnpm && pnpm install
+COPY ui/package.json ui/pnpm-lock.yaml ui/pnpm-workspace.yaml ./
+RUN npm install -g pnpm@10 && pnpm install --frozen-lockfile
 
 COPY ui/ .
 ENV VITE_API_BASE=/api


### PR DESCRIPTION
## Summary

The Release workflow has been red since the dependabot merges began (e.g. [run 27436244204](https://github.com/igarridot/Pentaract/actions/runs/27436244204)). The UI stage fails at \`pnpm install\` with:

\`\`\`
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.27.3
\`\`\`

The approval for esbuild's postinstall script lives in \`ui/pnpm-workspace.yaml\` (added in \`fed663d\`), but the Dockerfile was only copying \`package.json\` and \`pnpm-lock.yaml\` into the UI stage. With newer pnpm (10.26+) enforcing the policy stricter, the build started failing once a fresh \`pnpm install\` was forced.

Changes:
- Add \`ui/pnpm-workspace.yaml\` to the COPY so pnpm sees the approval.
- Pin pnpm to v10 (matches \`tests.yml\` and the lockfile) and use \`--frozen-lockfile\` for reproducibility.

## Test plan

- [x] \`docker build --target ui --platform linux/amd64 -f Dockerfile .\` succeeds locally (vite build outputs \`dist/\`)
- [ ] CI Release workflow goes green after merge