### PR TITLE
chore: bump pnpm to v11

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# UI build artifacts
+ui/node_modules
+ui/dist
+ui/.pnpm-store
+
+# Go build artifacts
+pentaract
+vendor
+
+# Local state never needed in the image
+.env
+persistent_data
+.pnpm-store
+
+# VCS / editor / OS noise
+.git
+.github
+.gitignore
+.gitattributes
+.vscode
+.idea
+.DS_Store
+*.swp
+*.swo
+
+# Tooling that ships with the repo but never runs in the image
+.claude

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM public.ecr.aws/docker/library/node:latest AS ui
 
 WORKDIR /app
 COPY ui/package.json ui/pnpm-lock.yaml ui/pnpm-workspace.yaml ./
-RUN npm install -g pnpm@10 && pnpm install --frozen-lockfile
+RUN npm install -g pnpm@11 && pnpm install --frozen-lockfile
 
 COPY ui/ .
 ENV VITE_API_BASE=/api

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,10 +24,5 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "vite": "^8.0.16"
-  },
-  "pnpm": {
-    "overrides": {
-      "yaml@<1.10.3": "^1.10.3"
-    }
   }
 }

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 allowBuilds:
   esbuild: true
+
+overrides:
+  yaml@<1.10.3: ^1.10.3


### PR DESCRIPTION
## Summary

Bumps pnpm from v10 to v11 to silence the upgrade notice that's been showing on every Docker build.

pnpm 11 has a handful of behavioral changes that needed addressing:

1. **`pnpm.overrides` in `package.json` is no longer read.** The yaml override for CVE-2026-33532 moves to `ui/pnpm-workspace.yaml`, the documented home in v11.
2. **`verifyDepsBeforeRun` now defaults to `install`**, so `pnpm run build` re-checks deps before scripts. This exposed a latent bug: `COPY ui/ .` in the `Dockerfile` was overwriting the freshly installed `/app/node_modules` with the host's `ui/node_modules`. With pnpm 10 the build silently used whatever the host had cached; pnpm 11 detected the drift and tried to reinstall — and failed in a non-TTY context. The fix is a proper `.dockerignore` so host artifacts (and noise like `.git`/`.claude`) never enter the build context.
3. Other pnpm 11 defaults (`minimumReleaseAge: 1440`, `strictDepBuilds: true`, `blockExoticSubdeps: true`) are accepted as-is. The first only affects re-resolution (we're on `--frozen-lockfile`), the others are already satisfied by our setup.

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds locally with pnpm 11.6.0
- [x] `pnpm test` — 55/55 passing
- [x] `pnpm run build` — produces the same bundle (`dist/assets/index-*.js` at 657.48 kB, identical to pnpm 10's output)
- [x] `docker build --target ui --platform linux/amd64 --no-cache` succeeds locally
- [x] Full multi-stage `docker build --no-cache` succeeds locally
- [ ] CI Release workflow goes green after merge