### PR TITLE
ci: auto-merge dependabot patch and minor bumps

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -45,7 +45,17 @@
       "Bash(git commit:*)",
       "Bash(git push:*)",
       "Bash(node -e \"const r = require\\('/Users/ivan.garrido/learning-workspace/Pentaract/ui/node_modules/react/package.json'\\); const rd = require\\('/Users/ivan.garrido/learning-workspace/Pentaract/ui/node_modules/react-dom/package.json'\\); console.log\\('react:', r.version, 'react-dom:', rd.version\\)\")",
-      "Bash(pnpm run:*)"
+      "Bash(pnpm run:*)",
+      "Bash(docker --version)",
+      "Bash(docker info *)",
+      "Bash(docker build *)",
+      "Bash(gh release *)",
+      "Bash(npx -y pnpm@11 --version)",
+      "Bash(npx -y pnpm@11 install --frozen-lockfile)",
+      "Bash(npx -y pnpm@11 test)",
+      "Bash(npx -y pnpm@11 run build)",
+      "Bash(git pull *)",
+      "Bash(git stash *)"
     ]
   }
 }

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge for safe dependabot updates
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+
+    steps:
+      - name: Fetch dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor bumps
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Closes the loop on the dependabot review story. Two changes already shipped:

- `groups: react` in `.github/dependabot.yml` keeps `react`/`react-dom`/`@types/react*` moving together, so the #157 class of mismatched bumps can't be opened anymore.
- `ui/src/common/react_versions.test.js` catches the mismatch in CI if it ever sneaks back in.

What's still manual is the actual merge click — I had to run `gh pr merge` eight times this session. This adds:

1. **Branch protection on `master`** (applied via API, not in this diff): required status checks `Go Tests` and `UI Tests`, `strict: true` so PRs must be up to date.
2. **`dependabot-auto-merge.yml`** workflow: on every dependabot PR, fetches the update metadata and enables GitHub's native auto-merge for patch/minor bumps. Majors are left alone — the test suite doesn't cover every regression a framework jump can cause, so those still need eyes.

Grouped PRs (like the react group) inherit the highest update-type in the group: if every package in the group is minor, it auto-merges; if any one is a major, it waits for review.

## Test plan

- [x] Branch protection live on `master` (`gh api repos/.../branches/master/protection`)
- [ ] First dependabot PR after merge auto-merges itself once CI is green (will observe next weekly run)