### PR TITLE
refactor(service): remove dead verification path, dedup retry helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,6 @@ All via environment variables (see `.env.example`). Key ones:
 | `UploadChunkParallelism` | 10 | Concurrent chunk uploads per file |
 | `UploadChunkMaxAttempts` | 5 | Retries per chunk upload |
 | `DownloadChunkMaxAttempts` | 3 | Retries per chunk download |
-| `VerifyChunkParallelism` | 10 | Max parallel verification downloads (standalone) |
 | `PipelineVerifyParallelism` | 5 | Concurrent verifications during upload pipeline |
 | `VerifyCBFailureThreshold` | 3 | Consecutive transient failures to trip circuit breaker |
 | `VerifyCBCooldownDuration` | 30s | Pause before retrying after circuit breaker trips |

--- a/internal/service/chunk_downloader.go
+++ b/internal/service/chunk_downloader.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"time"
 
 	"github.com/google/uuid"
 
@@ -51,8 +50,8 @@ func (m *StorageManager) downloadChunk(ctx context.Context, storage domain.Stora
 	if err == nil {
 		return data, nil
 	}
-	if contextAborted(ctx, err) {
-		return nil, contextAbortError(ctx, err)
+	if contextAborted(ctx) {
+		return nil, ctx.Err()
 	}
 	if !isGetFileFailure(err) {
 		return nil, err
@@ -73,8 +72,8 @@ func (m *StorageManager) downloadChunk(ctx context.Context, storage domain.Stora
 			slog.Info("chunk recovered via fallback worker", "position", chunk.Position, "worker", candidate.Name)
 			return data, nil
 		}
-		if contextAborted(ctx, tryErr) {
-			return nil, contextAbortError(ctx, tryErr)
+		if contextAborted(ctx) {
+			return nil, ctx.Err()
 		}
 		lastErr = tryErr
 	}
@@ -91,17 +90,14 @@ func (m *StorageManager) downloadChunkWithRetry(ctx context.Context, storage dom
 		if err == nil {
 			return data, nil
 		}
-		if contextAborted(ctx, err) {
-			return nil, contextAbortError(ctx, err)
+		if contextAborted(ctx) {
+			return nil, ctx.Err()
 		}
 		lastErr = err
 		if attempt < DownloadChunkMaxAttempts {
 			slog.Warn("download chunk failed, retrying", "position", chunk.Position, "attempt", attempt, "max_attempts", DownloadChunkMaxAttempts, "err", err)
-			backoff := time.Duration(attempt) * 500 * time.Millisecond
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(backoff):
+			if backoffErr := sleepBackoff(ctx, attempt); backoffErr != nil {
+				return nil, backoffErr
 			}
 		}
 	}

--- a/internal/service/chunk_uploader.go
+++ b/internal/service/chunk_uploader.go
@@ -34,7 +34,7 @@ func shouldRetryChunkUpload(ctx context.Context, err error) bool {
 	if err == nil {
 		return false
 	}
-	return !contextAborted(ctx, err)
+	return !contextAborted(ctx)
 }
 
 func (m *StorageManager) uploadChunkWithRetry(ctx context.Context, file *domain.File, storage *domain.Storage, position int16, chunkData []byte, plainHash [sha256.Size]byte) (uploadedChunkResult, error) {
@@ -75,11 +75,8 @@ func (m *StorageManager) uploadChunkWithRetry(ctx context.Context, file *domain.
 
 		slog.Warn("chunk upload failed, retrying", "position", position, "file", file.Path, "attempt", attempt, "max_attempts", UploadChunkMaxAttempts, "worker", wt.Name, "err", err)
 
-		backoff := time.Duration(attempt) * 500 * time.Millisecond
-		select {
-		case <-ctx.Done():
-			return uploadedChunkResult{}, ctx.Err()
-		case <-time.After(backoff):
+		if backoffErr := sleepBackoff(ctx, attempt); backoffErr != nil {
+			return uploadedChunkResult{}, backoffErr
 		}
 	}
 
@@ -112,7 +109,7 @@ func (m *StorageManager) verifySingleChunk(ctx context.Context, file *domain.Fil
 		chunkStartedAt := time.Now()
 		data, err := m.downloadAndDecryptChunkCached(ctx, file.ID, storage, chunk)
 		if err != nil {
-			if contextAborted(ctx, err) {
+			if contextAborted(ctx) {
 				return ctx.Err()
 			}
 			slog.Warn("chunk verification download failed", "position", result.Position, "file", file.Path, "attempt", attempt+1, "elapsed", time.Since(chunkStartedAt).Round(time.Millisecond), "err", err)
@@ -197,8 +194,8 @@ func (m *StorageManager) Upload(ctx context.Context, file *domain.File, reader i
 	g.SetLimit(uploadPar)
 
 	// S1: pipeline verification — verify chunks as they finish uploading.
-	// Uses PipelineVerifyParallelism (5) instead of VerifyChunkParallelism (10)
-	// to avoid saturating the Telegram API when running alongside uploads.
+	// Capped at PipelineVerifyParallelism (5) to avoid saturating the Telegram
+	// API when running alongside uploads.
 	verifyCh := make(chan uploadedChunkResult, uploadPar)
 	vg, vctx := errgroup.WithContext(ctx)
 	vg.SetLimit(PipelineVerifyParallelism)
@@ -221,7 +218,7 @@ func (m *StorageManager) Upload(ctx context.Context, file *domain.File, reader i
 			vg.Go(func() error {
 				err := m.verifySingleChunk(vctx, file, *storage, result)
 				if err != nil {
-					if contextAborted(vctx, err) {
+					if contextAborted(vctx) {
 						return err
 					}
 					// Hash mismatch is permanent — fail the upload immediately.
@@ -302,7 +299,7 @@ func (m *StorageManager) Upload(ctx context.Context, file *domain.File, reader i
 			result, err := m.uploadChunkWithRetry(gctx, file, storage, pos, chunkDataRef, plainHash)
 			if err != nil {
 				// Context cancellation → propagate immediately
-				if contextAborted(gctx, err) {
+				if contextAborted(gctx) {
 					return err
 				}
 				// Transient failure → save for second round instead of aborting
@@ -436,7 +433,7 @@ func (m *StorageManager) Upload(ctx context.Context, file *domain.File, reader i
 			}
 			err := m.verifySingleChunk(ctx, file, *storage, result)
 			if err != nil {
-				if contextAborted(ctx, err) {
+				if contextAborted(ctx) {
 					cleanupAllResults()
 					return ctx.Err()
 				}
@@ -509,54 +506,4 @@ func (m *StorageManager) Upload(ctx context.Context, file *domain.File, reader i
 	slog.Info("upload completed", "file", file.Path, "chunks", len(results), "storage", storage.Name, "chat", storage.Name)
 
 	return nil
-}
-
-// verifyUploadedChunks verifies each uploaded chunk by downloading it and comparing
-// its hash. Retained for backward compatibility with tests.
-func (m *StorageManager) verifyUploadedChunks(ctx context.Context, file *domain.File, storage domain.Storage, results []uploadedChunkResult, progress *UploadProgress) (failedPositions []int16, err error) {
-	if len(results) == 0 {
-		return nil, nil
-	}
-
-	parallelism := VerifyChunkParallelism
-	startedAt := time.Now()
-	slog.Info("verifying upload", "file", file.Path, "chunks", len(results), "parallelism", parallelism, "storage", storage.Name)
-
-	var mu sync.Mutex
-
-	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(parallelism)
-
-	for _, result := range results {
-		result := result
-		g.Go(func() error {
-			err := m.verifySingleChunk(gctx, file, storage, result)
-			if err != nil {
-				if contextAborted(gctx, err) {
-					return err
-				}
-				mu.Lock()
-				failedPositions = append(failedPositions, result.Position)
-				mu.Unlock()
-				return nil
-			}
-			if progress != nil {
-				progress.VerifiedChunks.Add(1)
-			}
-			return nil
-		})
-	}
-
-	if waitErr := g.Wait(); waitErr != nil {
-		slog.Error("upload verification aborted", "file", file.Path, "elapsed", time.Since(startedAt).Round(time.Millisecond), "err", waitErr)
-		return nil, waitErr
-	}
-
-	if len(failedPositions) > 0 {
-		slog.Error("upload verification completed with failures", "file", file.Path, "failed", len(failedPositions), "total", len(results), "elapsed", time.Since(startedAt).Round(time.Millisecond))
-		return failedPositions, fmt.Errorf("verification failed for %d chunk(s)", len(failedPositions))
-	}
-
-	slog.Info("upload verification completed", "file", file.Path, "chunks", len(results), "elapsed", time.Since(startedAt).Round(time.Millisecond))
-	return nil, nil
 }

--- a/internal/service/chunk_uploader_test.go
+++ b/internal/service/chunk_uploader_test.go
@@ -183,18 +183,7 @@ func TestShouldRetryChunkUpload(t *testing.T) {
 	}
 }
 
-func TestVerifyUploadedChunksEmpty(t *testing.T) {
-	m := &StorageManager{}
-	failedPos, err := m.verifyUploadedChunks(context.Background(), &domain.File{}, domain.Storage{}, nil, nil)
-	if err != nil {
-		t.Fatalf("expected nil for empty results, got: %v", err)
-	}
-	if len(failedPos) != 0 {
-		t.Fatalf("expected no failed positions, got: %v", failedPos)
-	}
-}
-
-func TestVerifyUploadedChunksContentMismatch(t *testing.T) {
+func TestVerifySingleChunkContentMismatch(t *testing.T) {
 	fileID := uuid.New()
 	storageID := uuid.New()
 	cipher := NewChunkCipher("secret")
@@ -233,29 +222,24 @@ func TestVerifyUploadedChunksContentMismatch(t *testing.T) {
 	// Provide a hash for "different-data" — verification should fail
 	differentHash := sha256Hash([]byte("different-data"))
 
-	results := []uploadedChunkResult{
-		{
-			TelegramFileID:    "FILE_ID",
-			TelegramMessageID: 1,
-			Position:          0,
-			PlainHash:         differentHash,
-		},
+	result := uploadedChunkResult{
+		TelegramFileID:    "FILE_ID",
+		TelegramMessageID: 1,
+		Position:          0,
+		PlainHash:         differentHash,
 	}
 
 	file := &domain.File{ID: fileID, StorageID: storageID}
-	failedPos, err := m.verifyUploadedChunks(context.Background(), file, domain.Storage{ID: storageID, ChatID: 123}, results, nil)
+	err = m.verifySingleChunk(context.Background(), file, domain.Storage{ID: storageID, ChatID: 123}, result)
 	if err == nil {
 		t.Fatal("expected content mismatch error")
 	}
-	if len(failedPos) != 1 || failedPos[0] != 0 {
-		t.Fatalf("expected failed position [0], got: %v", failedPos)
-	}
-	if !strings.Contains(err.Error(), "failed for 1 chunk") {
-		t.Fatalf("expected chunk failure error, got: %v", err)
+	if !isHashMismatch(err) {
+		t.Fatalf("expected hash mismatch error, got: %v", err)
 	}
 }
 
-func TestVerifyUploadedChunksRetriesTransientDownloadFailure(t *testing.T) {
+func TestVerifySingleChunkRetriesTransientDownloadFailure(t *testing.T) {
 	fileID := uuid.New()
 	storageID := uuid.New()
 	cipher := NewChunkCipher("secret")
@@ -299,22 +283,17 @@ func TestVerifyUploadedChunksRetriesTransientDownloadFailure(t *testing.T) {
 		chunkCipher: cipher,
 	}
 
-	results := []uploadedChunkResult{
-		{
-			TelegramFileID:    "FILE_ID",
-			TelegramMessageID: 1,
-			Position:          0,
-			PlainHash:         sha256Hash(plainData),
-		},
+	result := uploadedChunkResult{
+		TelegramFileID:    "FILE_ID",
+		TelegramMessageID: 1,
+		Position:          0,
+		PlainHash:         sha256Hash(plainData),
 	}
 
 	file := &domain.File{ID: fileID, StorageID: storageID}
-	failedPos, err := m.verifyUploadedChunks(context.Background(), file, domain.Storage{ID: storageID, ChatID: 123}, results, nil)
+	err = m.verifySingleChunk(context.Background(), file, domain.Storage{ID: storageID, ChatID: 123}, result)
 	if err != nil {
 		t.Fatalf("expected verification to succeed after retry, got: %v", err)
-	}
-	if len(failedPos) != 0 {
-		t.Fatalf("expected no failed positions, got: %v", failedPos)
 	}
 	// Should have needed more than 1 download attempt
 	if downloadAttempts.Load() <= 1 {

--- a/internal/service/constants.go
+++ b/internal/service/constants.go
@@ -9,14 +9,13 @@ const (
 	UploadChunkSize         = MaxTelegramGetFileBytes - UploadChunkSafetyMargin
 
 	// Upload tuning
-	UploadChunkMaxAttempts    = 5
-	UploadChunkParallelism    = 10
-	TokenBatchSize            = 5 // S2: pre-fetch multiple worker tokens per DB query
+	UploadChunkMaxAttempts = 5
+	UploadChunkParallelism = 10
+	TokenBatchSize         = 5 // S2: pre-fetch multiple worker tokens per DB query
 
 	// Download tuning
-	DownloadChunkMaxAttempts  = 3
-	DownloadChunkParallelism  = 5
-	VerifyChunkParallelism    = 10
+	DownloadChunkMaxAttempts = 3
+	DownloadChunkParallelism = 5
 
 	// Pipeline verification tuning
 	PipelineVerifyParallelism = 5                // concurrent verifications during upload (runs alongside uploads)

--- a/internal/service/storage_manager.go
+++ b/internal/service/storage_manager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/google/uuid"
 	"golang.org/x/sync/singleflight"
@@ -78,15 +79,21 @@ func validateEncryptedChunkSize(chunk []byte) error {
 // or has expired. HTTP client timeouts wrap context.DeadlineExceeded internally,
 // but those are transient errors that should be retried — so we only check the
 // parent context, not the error chain.
-func contextAborted(ctx context.Context, err error) bool {
+func contextAborted(ctx context.Context) bool {
 	return ctx != nil && ctx.Err() != nil
 }
 
-func contextAbortError(ctx context.Context, err error) error {
-	if ctx != nil && ctx.Err() != nil {
+// sleepBackoff waits attempt*500ms before the next retry, returning ctx.Err()
+// if the context is cancelled while waiting. Used by the chunk upload and
+// download retry loops.
+func sleepBackoff(ctx context.Context, attempt int) error {
+	backoff := time.Duration(attempt) * 500 * time.Millisecond
+	select {
+	case <-ctx.Done():
 		return ctx.Err()
+	case <-time.After(backoff):
+		return nil
 	}
-	return err
 }
 
 func (m *StorageManager) getStreamChunkCache() *streamChunkCache {


### PR DESCRIPTION
## Summary

Three behavior-preserving cleanups in the chunk service layer (net **−72 lines**). No functional change — `go test ./...` green.

### 1. Remove dead `verifyUploadedChunks()` + `VerifyChunkParallelism`
The function was dead production code — only its own tests called it. The live verification path is the pipeline inside `Upload()` (`verifySingleChunk` + circuit breaker). The constant `VerifyChunkParallelism` was its only user, now also removed (comment in `Upload` and the CLAUDE.md constants table updated).

The two substantive tests are **re-pointed at `verifySingleChunk`** (each already used a single-chunk slice), so hash-mismatch and transient-download-retry coverage is preserved — and now exercises live code instead of a dead wrapper. The trivial "empty input" test is dropped. The full round-trip + cleanup-on-mismatch is independently covered by `TestStorageManagerUploadVerifiesRoundTripAndCleansUpOnMismatch`.

### 2. Extract `sleepBackoff(ctx, attempt)`
The identical `attempt*500ms` + `ctx.Done()` select appeared verbatim in the upload and download retry loops. Centralized the backoff constant in one place.

### 3. Collapse `contextAborted` / `contextAbortError` into one `contextAborted(ctx)`
- The `err` parameter was never inspected — by design the helper only checks the parent context (HTTP timeouts wrap `DeadlineExceeded` but are transient and should retry). Removing the misleading param.
- `contextAbortError(ctx, err)` was only ever called inside a `contextAborted` guard, where it always returns `ctx.Err()`. Inlined at its 3 call sites and deleted.

## Test plan
- [x] `go build ./...` + `go vet ./...` clean
- [x] `go test ./...` all green
- [x] Verification behavior (hash mismatch, transient retry) still covered, now via the live `verifySingleChunk`